### PR TITLE
ci: test in a big endian architecture via github actions

### DIFF
--- a/.github/workflows/bigendian.yml
+++ b/.github/workflows/bigendian.yml
@@ -1,0 +1,25 @@
+name: build in a big endian architecture
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  # inspired by https://github.com/alpacahq/easyjson/blob/master/.github/workflows/easyjson.yml
+  test-non-amd64:
+    runs-on: ubuntu-latest
+    name: Test on ${{ matrix.distro }} ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: s390x
+            distro: ubuntu_latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: uraimo/run-on-arch-action@master
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ${{ matrix.distro }}
+          install: |
+            apt-get update
+            apt install -y build-essential
+          run: |
+            make


### PR DESCRIPTION
This adds a github action to test in a s390x (fancy!) emulated linux machine via qemu. This machine is big endian (like some HSMs). This action is a bit slow (compile and run takes about 10 mins) but seems worthy to catch endianness related bugs.

All tests pass.

Closes #9.